### PR TITLE
Add support for Completed Order 

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,7 +8,10 @@
   "dependencies": {
     "segmentio/analytics.js-integration": "^1.0.0",
     "segmentio/global-queue": "0.0.2",
-    "timoxley/next-tick": "0.0.2"
+    "timoxley/next-tick": "0.0.2",
+    "component/map": "~0.0.1",
+    "segmentio/facade": "1.5.0",
+    "ndhoule/foldl": "^1.0.3"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@
 var integration = require('analytics.js-integration');
 var push = require('global-queue')('_learnq');
 var tick = require('next-tick');
+var Track = require('segmentio-facade').Track;
+var foldl = require('foldl');
 
 /**
  * Trait aliases.
@@ -65,6 +67,7 @@ Klaviyo.prototype.loaded = function() {
  */
 
 Klaviyo.prototype.identify = function(identify) {
+  // TODO: should map/alias the rest of the reserved props
   var traits = identify.traits(traitAliases);
   if (!traits.$id && !traits.$email) return;
   push('identify', traits);
@@ -93,3 +96,67 @@ Klaviyo.prototype.track = function(track) {
     revenue: '$value'
   }));
 };
+
+/**
+ * Completed Order
+ *
+ * @param {Track} track
+ */
+
+Klaviyo.prototype.completedOrder = function(track) {
+  var products = formatProducts(track.products());
+  var payload = {
+    $event_id: track.orderId(),
+    $value: track.revenue(),
+    Categories: products.categories,
+    ItemNames: products.names,
+    Items: products.items
+  };
+
+  push('track', track.event(), payload);
+};
+
+/**
+ * Format products array.
+ *
+ * @param {Array} track
+ * @return {Array}
+ * @api private
+ */
+
+function formatProducts(products){
+  return foldl(function(payloads, props){
+    var product = new Track({ properties: props });
+    payloads.categories.push(product.category());
+    payloads.names.push(product.name());
+    payloads.items.push(reject({
+      SKU: product.sku(),
+      Name: product.name(),
+      Quantity: product.quantity(),
+      ItemPrice: product.price(),
+      RowTotal: product.price(),
+      Categories: [product.category()],
+      ProductURL: product.proxy('properties.productUrl'),
+      ImageURL: product.proxy('properties.imageUrl')
+    }));
+
+    return payloads;
+  }, { categories: [], names: [], items: [] }, products);
+}
+
+/**
+ * Return a copy of an object, less an  `undefined` values.
+ *
+ * @param {Object} obj
+ * @return {Object}
+ * @api private
+ */
+
+function reject(obj) {
+  return foldl(function(result, val, key) {
+    if (val !== undefined) {
+      result[key] = val;
+    }
+    return result;
+  }, {}, obj);
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,7 +9,7 @@ describe('Klaviyo', function() {
   var analytics;
   var klaviyo;
   var options = {
-    apiKey: 'x'
+    apiKey: 'hfWBjc'
   };
 
   beforeEach(function() {
@@ -90,8 +90,8 @@ describe('Klaviyo', function() {
       });
 
       it('should send an id and traits', function() {
-        analytics.identify('id', { trait: true });
-        analytics.called(window._learnq.push, ['identify', { $id: 'id', trait: true }]);
+        analytics.identify('horseRadish', { email: 'horses@horses.com', foo: true });
+        analytics.called(window._learnq.push, ['identify', { $id: 'horseRadish', $email: 'horses@horses.com', foo: true }]);
       });
 
       it('should alias traits', function() {
@@ -142,6 +142,65 @@ describe('Klaviyo', function() {
       it('should alias revenue to `$value`', function() {
         analytics.track('event', { revenue: 90 });
         analytics.called(window._learnq.push, ['track', 'event', { $value: 90 }]);
+      });
+
+      it('should send completed order', function(){
+        analytics.track('Completed Order', {
+          orderId: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games',
+              productUrl: 'http://www.example.com/path/to/product',
+              imageUrl: 'http://www.example.com/path/to/product/image.png'
+            },
+            {
+              id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Suh dude',
+              price: 17.38,
+              quantity: 2,
+              category: 'Interwebs'
+            }
+          ]
+        });
+        analytics.called(window._learnq.push, ['track', 'Completed Order', {
+          $event_id: '50314b8e9bcf000000000000',
+          $value: 25,
+          Categories: ['Games', 'Interwebs'],
+          ItemNames: ['Monopoly: 3rd Edition', 'Suh dude'],
+          Items: [
+            {
+              SKU: '45790-32',
+              Name: 'Monopoly: 3rd Edition',
+              Quantity: 1,
+              ItemPrice: 19,
+              RowTotal: 19,
+              ProductURL: 'http://www.example.com/path/to/product',
+              ImageURL: 'http://www.example.com/path/to/product/image.png',
+              Categories: ['Games']
+            },
+            {
+              SKU: '46493-32',
+              Name: 'Suh dude',
+              Quantity: 2,
+              ItemPrice: 17.38,
+              RowTotal: 17.38,
+              Categories: ['Interwebs']
+            }
+          ]
+        }]);
       });
     });
   });


### PR DESCRIPTION
This PR should be released in tandem with the server side [PR #8](https://github.com/segmentio/integration-klaviyo/pull/8)

Main purpose of this PR is to achieve parity with our server side integration since previously we were not semantically catching `Completed Order` events on the client side. 

**TODO:** 

- Comms to mutual clients about these PRs' potential to break reports. Both server side and client side will send these events as `Completed Order`, *not* `Placed Order` like what it used to be. 

I based this PR based on the code sample the Andrew, the CEO of Klaviyo, provided:

```js
_learnq.push(['account', 'API_KEY']);

_learnq.push(['identify', {
  "$email" : "john.smith@example.com",
  "$first_name" : "John",
  "$last_name" : "Smith"
}]);

_learnq.push(['track', 'Placed Order', {
  "$event_id" : "1234",
  "$value" : 29.98,
  "Categories" : ["Fiction", "Classics", "Children"],
  "ItemNames" : ["Winnie the Pooh", "A Tale of Two Cities"],
  "Brands" : ["Kids Books", "Harcourt Classics"],
  "Items" : [
    {
      "SKU" : "WINNIEPOOH",
      "Name" : "Winnie the Pooh",
      "Quantity" : 1,
      "ItemPrice" : 9.99,
      "RowTotal" : 9.99,
      "ProductURL" : "http://www.example.com/path/to/product",
      "ImageURL" : "http://www.example.com/path/to/product/image.png",
      "Categories" : ["Fiction", "Children"],
      "Brand" : "Kids Books"
    },
    {
      "SKU" : "TALEOFTWO",
      "Name" : "A Tale of Two Cities",
      "Quantity" : 1,
      "ItemPrice" : 19.99,
      "RowTotal" : 19.99,
      "ProductURL" : "http://www.example.com/path/to/product2",
      "ImageURL" : "http://www.example.com/path/to/product/image2.png",
      "Categories" : ["Fiction", "Classics"],
      "Brand" : "Harcourt Classics"
    }
  ]
}]);
```

@f2prateek @sperand-io -- is there anyway I can test this implementation locally and see the data in the Klaviyo account? I just want a sanity check that the end-to-end is there.