### PR TITLE
send ordered product event per product

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -102,6 +102,7 @@ Klaviyo.prototype.track = function(track) {
 /**
  * Completed Order
  *
+ * http://learn.klaviyo.com/12887-Ecommerce:-Other-Integrations/product-activity-integrating-a-custom-ecommerce-cart-or-platform
  * @param {Track} track
  */
 
@@ -134,6 +135,14 @@ Klaviyo.prototype.completedOrder = function(track) {
   payload = extend(payload, topLevelCustomProps);
 
   push('track', track.event(), payload);
+
+  // Formulate payload per product to send
+  var productProperties = formatItems(track);
+
+  // Send a separate event for each product
+  for (var x = 0; x < productProperties.length; x++) {
+    push('track', 'Ordered Product', productProperties[x]);
+  }
 };
 
 
@@ -151,6 +160,51 @@ function filter(facade, list){
     remove(ret, list[x]);
   }
   return ret;
+}
+
+/**
+ * Format payload for each product.
+ *
+ * @param {Track} track
+ * @return {Array}
+ * @api private
+ */
+
+function formatItems(track){
+  return foldl(function(payloads, props){
+    var product = new Track({ properties: props });
+    var itemWhitelist = [
+      '$event_id',
+      '$value',
+      'name',
+      'product categories',
+      'category',
+      'id',
+      'sku',
+      'quantity',
+      'price',
+      'productUrl',
+      'imageUrl'
+    ];
+
+    // filter standard item props so we can merge custom props later
+    var itemCustomProps = filter(product, itemWhitelist);
+
+    var item = reject({
+      $event_id: product.id() || track.orderId() + '_' + product.sku(),
+      $value: product.price(),
+      Name: product.name(),
+      Quantity: product.quantity(),
+      ProductCategories: [product.category()],
+      ProductURL: product.proxy('properties.productUrl'),
+      ImageURL: product.proxy('properties.imageUrl')
+    });
+
+    item = extend(item, itemCustomProps);
+    payloads.push(item);
+
+    return payloads;
+  }, [], track.products());
 }
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -210,6 +210,65 @@ describe('Klaviyo', function() {
         }]);
       });
 
+      it('should send an event for each product', function(){
+        analytics.track('Completed Order', {
+          orderId: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games',
+              productUrl: 'http://www.example.com/path/to/product',
+              imageUrl: 'http://www.example.com/path/to/product/image.png'
+            }
+          ]
+        });
+        analytics.calledTwice(window._learnq.push);
+        analytics.called(window._learnq.push, ['track', 'Completed Order', {
+          $event_id: '50314b8e9bcf000000000000',
+          $value: 25,
+          Categories: ['Games'],
+          ItemNames: ['Monopoly: 3rd Edition'],
+          Items: [
+            {
+              id: '507f1f77bcf86cd799439011',
+              SKU: '45790-32',
+              Name: 'Monopoly: 3rd Edition',
+              Quantity: 1,
+              ItemPrice: 19,
+              RowTotal: 19,
+              ProductURL: 'http://www.example.com/path/to/product',
+              ImageURL: 'http://www.example.com/path/to/product/image.png',
+              Categories: ['Games']
+            }
+          ],
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD'
+        }]);
+        analytics.called(window._learnq.push, ['track', 'Ordered Product', {
+         $event_id: '507f1f77bcf86cd799439011',
+         $value: 19,
+         Name: 'Monopoly: 3rd Edition',
+         Quantity: 1,
+         ProductCategories: ['Games'],
+         ProductURL: 'http://www.example.com/path/to/product',
+         ImageURL: 'http://www.example.com/path/to/product/image.png'
+        }]);
+      });
+
       it('should let custom props pass', function(){
         analytics.track('Completed Order', {
           orderId: '50314b8e9bcf000000000000',


### PR DESCRIPTION
The server side sends a separate request PER product. 

Not sure how this never came up but we were NOT doing this for the client side. This PR will push a `Ordered Product` event for every product in the `properties.products` array.

@segment-integrations/core 