### PR TITLE
Load the latest Klaviyo javascript

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ var Klaviyo = module.exports = integration('Klaviyo')
   .assumesPageview()
   .global('_learnq')
   .option('apiKey', '')
-  .tag('<script src="//a.klaviyo.com/media/js/learnmarklet.js">');
+  .tag('<script src="//a.klaviyo.com/media/js/analytics/analytics.js">');
 
 /**
  * Initialize.


### PR DESCRIPTION
The integration currently [loads](https://github.com/segment-integrations/analytics.js-integration-klaviyo/blob/2.1.1/lib/index.js#L36) `//a.klaviyo.com/media/js/learnmarklet.js` as the Klaviyo script tag.

However, in recent Klaviyo [getting started documentation](https://www.klaviyo.com/docs/getting-started) the following url is listed:  `//a.klaviyo.com/media/js/analytics/analytics.js`.