### PR TITLE
ensure unique  for ordered product events

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+2.1.2 / 2016-10-18
+==================
+
+  * Ensure unique $event_id for auto-generated  ordered product events
+
 2.1.1 / 2016-09-07
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -195,7 +195,6 @@ function formatItems(track) {
     var itemCustomProps = filter(product, itemWhitelist);
 
     var item = reject({
-      $event_id: product.productId() || product.id() || track.orderId() + '_' + product.sku(),
       $value: product.price(),
       Name: product.name(),
       Quantity: product.quantity(),
@@ -204,6 +203,11 @@ function formatItems(track) {
       ImageURL: product.proxy('properties.imageUrl'),
       SKU: product.sku()
     });
+
+    // ensure unique $event_id is associated with each Ordered Product event by combining Order Completed
+    //  order_id and product's productId or SKU
+    var identifier = product.productId() || product.id() || product.sku();
+    item.$event_id = track.orderId() + '_' + identifier;
 
     item = extend(item, itemCustomProps);
     payloads.push(item);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-klaviyo",
   "description": "The Klaviyo analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -260,7 +260,78 @@ describe('Klaviyo', function() {
           currency: 'USD'
         }]);
         analytics.called(window._learnq.push, ['track', 'Ordered Product', {
-          $event_id: '507f1f77bcf86cd799439011',
+          $event_id: '50314b8e9bcf000000000000_507f1f77bcf86cd799439011',
+          $value: 19,
+          Name: 'Monopoly: 3rd Edition',
+          Quantity: 1,
+          ProductCategories: ['Games'],
+          ProductURL: 'http://www.example.com/path/to/product',
+          ImageURL: 'http://www.example.com/path/to/product/image.png',
+          SKU: '45790-32'
+        }]);
+      });
+
+      it('should have the correct $event_id for Ordered Product if id passed as product_id', function() {
+        analytics.track('Completed Order', {
+          order_id: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games',
+              productUrl: 'http://www.example.com/path/to/product',
+              imageUrl: 'http://www.example.com/path/to/product/image.png'
+            }
+          ]
+        });
+        analytics.calledTwice(window._learnq.push);
+        analytics.called(window._learnq.push, ['track', 'Ordered Product', {
+          $event_id: '50314b8e9bcf000000000000_507f1f77bcf86cd799439011',
+          $value: 19,
+          Name: 'Monopoly: 3rd Edition',
+          Quantity: 1,
+          ProductCategories: ['Games'],
+          ProductURL: 'http://www.example.com/path/to/product',
+          ImageURL: 'http://www.example.com/path/to/product/image.png',
+          SKU: '45790-32'
+        }]);
+      });
+
+      it('should have the correct $event_id for Ordered Product if sku is passed and not id or produt_id', function() {
+        analytics.track('Completed Order', {
+          order_id: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games',
+              productUrl: 'http://www.example.com/path/to/product',
+              imageUrl: 'http://www.example.com/path/to/product/image.png'
+            }
+          ]
+        });
+        analytics.calledTwice(window._learnq.push);
+        analytics.called(window._learnq.push, ['track', 'Ordered Product', {
+          $event_id: '50314b8e9bcf000000000000_45790-32',
           $value: 19,
           Name: 'Monopoly: 3rd Edition',
           Quantity: 1,


### PR DESCRIPTION
This PR ensures that each "Ordered Product" event contained a unique `$event_id`. Segment currently sends `productId` as `$event_id` for "Ordered Product" events. Klaviyo requires that `$event_ids` are unique - productIds are not unique, so subsequent events containing existing $event_ids are rejected by Klaviyo.

The issue is affecting customers and is described in this JIRA ticket: https://segment.atlassian.net/browse/BUGS-630

This update should not be a breaking change. We're simply updating the format of $event_id for future events to ensure that this id is always unique for new events. Klaviyo outlines this requirement in their docs here: https://www.klaviyo.com/docs

PR for docs update: https://github.com/segmentio/site-docs/pull/1985